### PR TITLE
Fix mobile background image visibility in VideoPlayer component

### DIFF
--- a/src/components/VideoPlayer.jsx
+++ b/src/components/VideoPlayer.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import styles from "./VideoPlayer.module.css";
 
 const VideoPlayer = ({
@@ -10,6 +10,23 @@ const VideoPlayer = ({
   const videoRef = useRef(null);
   const [error, setError] = useState(null);
   const [showVideo, setShowVideo] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      const mobile =
+        window.matchMedia("(max-width: 768px)").matches ||
+        /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+          navigator.userAgent
+        );
+      setIsMobile(mobile);
+    };
+
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
 
   const handlePlayClick = () => {
     setShowVideo(true);
@@ -109,7 +126,7 @@ const VideoPlayer = ({
           backgroundSize: "cover",
           backgroundPosition: "center",
           backgroundRepeat: "no-repeat",
-          backgroundAttachment: "fixed",
+          backgroundAttachment: isMobile ? "scroll" : "fixed",
           zIndex: 1,
         }}
       />


### PR DESCRIPTION
- Add mobile device detection using useEffect hook
- Conditionally set backgroundAttachment based on device type
- Use 'scroll' for mobile devices to fix background image visibility
- Keep 'fixed' for desktop to maintain parallax effect
- Fixes issue where background image was not showing on mobile browsers